### PR TITLE
Rebuild for python 3.10 on linux-64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  # trigger 1
   skip: True  # [py<35 or win32]
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]


### PR DESCRIPTION
protobuf 3.19.1 is missing for python 3.10 on linux-64:

https://repo.anaconda.com/pkgs/main/linux-64
protobuf-3.19.1-py37h295c915_0.tar.bz2
protobuf-3.19.1-py38h295c915_0.tar.bz2
protobuf-3.19.1-py39h295c915_0.tar.bz2