### PR TITLE
3.20.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  build: libprotobuf

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  build: libprotobuf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/protobuf-v{{ version }}.tar.gz
-  sha256: 9c0fd39c7a08dff543c643f0f4baf081988129a411b977a07c46221793605638
+  sha256: a4d420a7b727a183475641c2b372389395101bc06aa00525720039fb3a9d8389
   patches:  # [py==311]
     # see https://github.com/protocolbuffers/protobuf/pull/10403
     - patches/0001-fix-build-with-python-311.patch  # [py==311]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/protobuf-v{{ version }}.tar.gz
-  sha256: a4d420a7b727a183475641c2b372389395101bc06aa00525720039fb3a9d8389
+  sha256: 9c0fd39c7a08dff543c643f0f4baf081988129a411b977a07c46221793605638
   patches:  # [py==311]
     # see https://github.com/protocolbuffers/protobuf/pull/10403
     - patches/0001-fix-build-with-python-311.patch  # [py==311]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,6 @@ source:
 
 build:
   number: 0
-  skip: True
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-fix-build-with-python-311.patch  # [py==311]
 
 build:
-  number: 1
+  number: 0
   skip: True  # [win32]
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [win32]
+  skip: True
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.20.1" %}
+{% set version = "3.20.3" %}
 
 package:
   name: protobuf
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/protobuf-v{{ version }}.tar.gz
-  sha256: 8b28fdd45bab62d15db232ec404248901842e5340299a57765e48abe8a80d930
+  sha256: 9c0fd39c7a08dff543c643f0f4baf081988129a411b977a07c46221793605638
   patches:  # [py==311]
     # see https://github.com/protocolbuffers/protobuf/pull/10403
     - patches/0001-fix-build-with-python-311.patch  # [py==311]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,7 +57,6 @@ about:
     mechanism for serializing structured data,think XML, but smaller, faster, and simpler.
   dev_url: https://github.com/protocolbuffers/protobuf
   doc_url: https://developers.google.com/protocol-buffers/docs/tutorials
-  doc_source_url: https://github.com/protocolbuffers/protobuf/blob/master/README.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
# protobuf 3.20.3

jira: https://anaconda.atlassian.net/browse/PKG-689
upstream: https://github.com/protocolbuffers/protobuf/tree/v3.20.3
diff: https://github.com/protocolbuffers/protobuf/compare/v3.20.1...v3.20.3
license: https://github.com/protocolbuffers/protobuf/blob/v3.20.3/LICENSE

## Changes
- Update version and SHA

## Notes
- This fixes two CVEs: CVE-2022-3171 and CVE-2022-1941
- Once https://github.com/AnacondaRecipes/libprotobuf-feedstock/pull/18 is merged, `abs.yaml` will be removed before merging.

## Related PRs
- https://github.com/AnacondaRecipes/libprotobuf-feedstock/pull/18