### PR TITLE
3.19.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  build: libprotobuf

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  build: libprotobuf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/protobuf-v{{ version }}.tar.gz
-  sha256: 6ee46b428fd080150d6c48335bc89a5296820df709b27678ce522dc27d211329
+  sha256: 9a301cf94a8ddcb380b901e7aac852780b826595075577bb967004050c835056
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<35 or win32]
+  skip: True  # [py<35]
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,6 @@ about:
     mechanism for serializing structured data,think XML, but smaller, faster, and simpler.
   dev_url: https://github.com/protocolbuffers/protobuf
   doc_url: https://developers.google.com/protocol-buffers/docs/tutorials
-  doc_source_url: https://github.com/protocolbuffers/protobuf/blob/master/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.19.1" %}
+{% set version = "3.19.6" %}
 
 package:
   name: protobuf
@@ -6,11 +6,10 @@ package:
 
 source:
   url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/protobuf-v{{ version }}.tar.gz
-  sha256: 87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422
+  sha256: 6ee46b428fd080150d6c48335bc89a5296820df709b27678ce522dc27d211329
 
 build:
   number: 0
-  # trigger 1
   skip: True  # [py<35 or win32]
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]


### PR DESCRIPTION
# libprotobuf 3.19.6

jira: https://anaconda.atlassian.net/browse/PKG-689
upstream: https://github.com/protocolbuffers/protobuf/tree/v3.19.6
license: https://github.com/protocolbuffers/protobuf/blob/v3.19.6/LICENSE

## Changes
- Update version and SHA

## Notes
- This fixes two CVEs: CVE-2022-3171 and CVE-2022-1941
- Once https://github.com/AnacondaRecipes/libprotobuf-feedstock/pull/20 is deployed, `abs.,yaml` needs to be removed

## Related PRs
- https://github.com/AnacondaRecipes/libprotobuf-feedstock/pull/20
- https://github.com/AnacondaRecipes/protobuf-feedstock/pull/18
